### PR TITLE
Add border type parameter to demosaicing API

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -3806,7 +3806,9 @@ The function can do the following transformations:
 
 @sa cvtColor
 */
-CV_EXPORTS_W void demosaicing(InputArray src, OutputArray dst, int code, int dstCn = 0);
+CV_EXPORTS_W void demosaicing(InputArray src, OutputArray dst, int code,
+                              int dstCn = 0,
+                              int borderType = BORDER_REFLECT_101);
 
 //! @} imgproc_color_conversions
 

--- a/modules/imgproc/src/color.cpp
+++ b/modules/imgproc/src/color.cpp
@@ -316,7 +316,7 @@ void cvtColor( InputArray _src, OutputArray _dst, int code, int dcn, AlgorithmHi
                     _src.copyTo(src);
                 else
                     src = _src.getMat();
-                demosaicing(src, _dst, code, dcn);
+                demosaicing(src, _dst, code, dcn, BORDER_REFLECT_101);
                 break;
             }
 

--- a/modules/imgproc/src/demosaicing.cpp
+++ b/modules/imgproc/src/demosaicing.cpp
@@ -1073,13 +1073,16 @@ static void Bayer2RGB_( const Mat& srcmat, Mat& dstmat, int code )
 
 /////////////////// Demosaicing using Variable Number of Gradients ///////////////////////
 
-static void Bayer2RGB_VNG_8u( const Mat& srcmat, Mat& dstmat, int code )
+static void Bayer2RGB_VNG_8u( const Mat& srcmat, Mat& dstmat, int code, int borderType )
 {
-    const uchar* bayer = srcmat.ptr();
-    int bstep = (int)srcmat.step;
+    Mat src;
+    cv::copyMakeBorder(srcmat, src, 2, 2, 2, 2, borderType);
+
+    const uchar* bayer = src.ptr();
+    int bstep = (int)src.step;
     uchar* dst = dstmat.ptr();
     int dststep = (int)dstmat.step;
-    Size size = srcmat.size();
+    Size size = src.size();
 
     int blueIdx = code == COLOR_BayerBG2BGR_VNG || code == COLOR_BayerGB2BGR_VNG ? 0 : 2;
     bool greenCell0 = code != COLOR_BayerBG2BGR_VNG && code != COLOR_BayerRG2BGR_VNG;
@@ -1754,7 +1757,8 @@ static void Bayer2RGB_EdgeAware_T(const Mat& src, Mat& dst, int code)
 //                           The main Demosaicing function                              //
 //////////////////////////////////////////////////////////////////////////////////////////
 
-void cv::demosaicing(InputArray _src, OutputArray _dst, int code, int dcn)
+void cv::demosaicing(InputArray _src, OutputArray _dst, int code, int dcn,
+                     int borderType)
 {
     CV_INSTRUMENT_REGION();
 
@@ -1812,7 +1816,7 @@ void cv::demosaicing(InputArray _src, OutputArray _dst, int code, int dcn)
             else
             {
                 CV_Assert( depth == CV_8U );
-                Bayer2RGB_VNG_8u(src, dst_, code);
+                Bayer2RGB_VNG_8u(src, dst_, code, borderType);
             }
         }
         break;

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -3069,7 +3069,7 @@ TEST(ImgProc_BayerEdgeAwareDemosaicing, accuracy)
             CV_Assert(!bayer.empty() && (bayer.type() == CV_8UC1 || bayer.type() == CV_16UC1));
 
             Mat actual;
-            cv::demosaicing(bayer, actual, COLOR_BayerBG2BGR_EA + i);
+            cv::demosaicing(bayer, actual, COLOR_BayerBG2BGR_EA + i, 0, cv::BORDER_REFLECT_101);
 
             if (t == 0)
                 checkData<unsigned char>(actual, reference, ts, types[i], next, "CV_8U");


### PR DESCRIPTION
## Summary
- extend `demosaicing` with a `borderType` argument
- pass new argument from `cvtColor` and tests
- pad Bayer image inside `Bayer2RGB_VNG_8u`

## Testing
- `git status --short`